### PR TITLE
Change logic of ordered_entities

### DIFF
--- a/lib/seed_builder/core.rb
+++ b/lib/seed_builder/core.rb
@@ -36,7 +36,7 @@ module SeedBuilder
       rels = @domain.relationships.dup # 全リレーション
       entities = []
       while rels.count > 0
-        rels.each do |rel|
+        rels.dup.each do |rel|
           src = rel[:src]
           if rels.select{ |r| r[:dst].name == src.name }.size.zero?
             entities << src
@@ -44,7 +44,7 @@ module SeedBuilder
           end
         end
       end
-      entities
+      entities.uniq
     end
 
   end

--- a/lib/seed_builder/core.rb
+++ b/lib/seed_builder/core.rb
@@ -30,7 +30,7 @@ module SeedBuilder
       entities.concat @domain.entities
     end
 
-    # @ordered_entities に次々に要素をいれていく
+    # entities に親モデルから次々に要素をいれていく
     # @return [Array<Entity>]
     def ordered_entities_from_relationships
       rels = @domain.relationships.dup # 全リレーション

--- a/lib/seed_builder/core.rb
+++ b/lib/seed_builder/core.rb
@@ -25,14 +25,26 @@ module SeedBuilder
     #
     # @return [Array<ActiveRecord::Base>]
     def ordered_entities
-      entities = []
-      @domain.relationships.each do |rel|
-        next if entities.include? rel[:src]
-        next unless @domain.relationships.select{|r| rel[:src].name == r[:dst].name}.size.zero?
-        entities << rel[:src]
-        @domain.entities.delete_if{|r| rel[:src].name == r.name}
-      end
+      entities = ordered_entities_from_relationships
+      @domain.entities.delete_if{|r| entities.map(&:name).include?(r.name)}
       entities.concat @domain.entities
+    end
+
+    # @ordered_entities に次々に要素をいれていく
+    # @return [Array<Entity>]
+    def ordered_entities_from_relationships
+      rels = @domain.relationships.dup # 全リレーション
+      entities = []
+      while rels.count > 0
+        rels.each do |rel|
+          src = rel[:src]
+          if rels.select{|r| r[:dst].name == src.name }.size.zero?
+            entities << src
+            rels.reject!{|r| r[:src].name == src.name }
+          end
+        end
+      end
+      entities
     end
 
   end

--- a/lib/seed_builder/core.rb
+++ b/lib/seed_builder/core.rb
@@ -26,7 +26,7 @@ module SeedBuilder
     # @return [Array<ActiveRecord::Base>]
     def ordered_entities
       entities = ordered_entities_from_relationships
-      @domain.entities.delete_if{|r| entities.map(&:name).include?(r.name)}
+      @domain.entities.delete_if{ |r| entities.map(&:name).include?(r.name) }
       entities.concat @domain.entities
     end
 
@@ -38,9 +38,9 @@ module SeedBuilder
       while rels.count > 0
         rels.each do |rel|
           src = rel[:src]
-          if rels.select{|r| r[:dst].name == src.name }.size.zero?
+          if rels.select{ |r| r[:dst].name == src.name }.size.zero?
             entities << src
-            rels.reject!{|r| r[:src].name == src.name }
+            rels.reject!{ |r| r[:src].name == src.name }
           end
         end
       end

--- a/lib/seed_builder/entity.rb
+++ b/lib/seed_builder/entity.rb
@@ -25,8 +25,13 @@ module SeedBuilder
       # TODO: このロジックをメソッドに抽出したい
       polymorphic_columns.each do |column|
         belongs_to = polymorphic_belongs.sample
-        entity[column[:type] + "_type"] = belongs_to.active_record.name
-        entity[column[:foreign_key]] = belongs_to.active_record.all.sample.id
+        if belongs_to
+          entity[column[:type] + "_type"] = belongs_to&.active_record.name
+          entity[column[:foreign_key]]    = belongs_to.active_record.all.sample.id
+        else
+          entity[column[:type] + "_type"] = nil
+          entity[column[:foreign_key]]    = nil
+        end
       end
 
       entity.save

--- a/lib/seed_builder/entity.rb
+++ b/lib/seed_builder/entity.rb
@@ -26,7 +26,7 @@ module SeedBuilder
       polymorphic_columns.each do |column|
         belongs_to = polymorphic_belongs.sample
         if belongs_to
-          entity[column[:type] + "_type"] = belongs_to&.active_record.name
+          entity[column[:type] + "_type"] = belongs_to.active_record.name
           entity[column[:foreign_key]]    = belongs_to.active_record.all.sample.id
         else
           entity[column[:type] + "_type"] = nil


### PR DESCRIPTION
# Check working

```
pry(main)> SeedBuilder::Core.new.send(:ordered_entities).map{|m|m.name}
=> ["User",
 "Subject",
 "Theme",
 "Company",
 "Admin",
 "Client",
 "Category",
 "Image",
 "Problem",
 "Solution",
 "AdminBlog",
 "Case",
 "SolutionBlog",
 "Contact",
 "Document",
 "Tag",
 "Download",
 "Role",
 "HABTM_Accounts",
 "CvAnswer",
 "CvUser",
 "SolutionMark",
 "ArticleImage",
 "ArticleTag",
 "ArticlesCategory",
 "ArticlesProblem",
 "DocumentsCategory",
 "DocumentsProblem",
 "Pageview",
 "PdfImage",
 "SolutionImage",
 "SolutionsCategory",
 "SolutionsProblem",
 "UserAccount",
 "UserTmpEmail"]
```