### PR TITLE
Add case if options has :is

### DIFF
--- a/lib/seed_builder/valid/string.rb
+++ b/lib/seed_builder/valid/string.rb
@@ -63,8 +63,11 @@ module SeedBuilder
 
       # @return [Integer] 文字数
       def num_of_chars
-        # ex) {:minimum=>5, :maximum=>9}
+        # ex) {:minimum=>5, :maximum=>9} or {:is=>7}
         merged_options = length_validators.map(&:options).inject({}, :merge)
+
+        is = merged_options[:is]
+        return is if is
 
         minimum = merged_options[:minimum] || 0
         maximum = merged_options[:maximum] || 16


### PR DESCRIPTION
# Fix

```bash
$ rspec spec/attribute_spec.rb:111
Run options: include {:locations=>{"./spec/attribute_spec.rb"=>[111]}}

SeedBuilder::Attribute
  build
    string type
      should be valid data by match length

Finished in 0.03464 seconds (files took 1.39 seconds to load)
1 example, 0 failures
```