### PR TITLE
Add case of InclusionValidator

### DIFF
--- a/lib/seed_builder/valid/string.rb
+++ b/lib/seed_builder/valid/string.rb
@@ -14,20 +14,20 @@ module SeedBuilder
 
         case validator_names
 
-          # Regex だけを考える
-          when include_format?
-            return formatted_str
+        when include_inclusion?
+          return included_str
 
-          # Integer を返す
-          when include_numericality?
-            first_str = rand(1..9).to_s
-            rest_str = (1...num_of_chars).map{rand(0..9)}.join
-            return data = first_str + rest_str
+        when include_format?
+          return formatted_str
 
-          # String を返す
-          else
-            data = (1..num_of_chars).map{('a'..'z').to_a[rand(26)]}.join
-            return data
+        when include_numericality?
+          first_str = rand(1..9).to_s
+          rest_str = (1...num_of_chars).map{rand(0..9)}.join
+          return data = first_str + rest_str
+
+        else
+          data = (1..num_of_chars).map{('a'..'z').to_a[rand(26)]}.join
+          return data
         end
       end
 
@@ -36,6 +36,11 @@ module SeedBuilder
 
       def email_str
         "#{SecureRandom.hex(8)}@example.com"
+      end
+
+      def included_str
+        arr = inclusion_validator.options[:in]
+        arr.sample
       end
 
       def formatted_str
@@ -55,6 +60,13 @@ module SeedBuilder
         }
       end
 
+      # NOTE: Use last validator
+      def inclusion_validator
+        validators.select{ |m|
+          m.class.name.demodulize == "InclusionValidator"
+        }.last
+      end
+
       def format_validators
         validators.select{ |m|
           m.class.name.demodulize == "FormatValidator"
@@ -71,6 +83,10 @@ module SeedBuilder
         rand(minimum..maximum)
       end
 
+
+      def include_inclusion?
+        ->(arr){ arr.include? "InclusionValidator" }
+      end
 
       def include_format?
         ->(arr){ arr.include? "FormatValidator" }


### PR DESCRIPTION
# Fix for spec/attribute_spec.rb:67

```bash
$ rspec spec/attribute_spec.rb:67
Run options: include {:locations=>{"./spec/attribute_spec.rb"=>[67]}}

SeedBuilder::Attribute
  build
    string type
      should be valid data by inclusion

Finished in 0.0444 seconds (files took 1.6 seconds to load)
1 example, 0 failures
```
